### PR TITLE
workaround for bug/behaviour in otlp-metrics-exporter

### DIFF
--- a/Backend/backend.js
+++ b/Backend/backend.js
@@ -114,10 +114,7 @@ class ServiceResourceDetector {
 }
 
 async function opentelemetry_init() {
-  let sdk;
-  try {
-    sdk = opentelemetry_create();
-  } catch(e){}
+  let sdk = opentelemetry_create();
   process.on('exit', () => sdk.shutdown());
   process.on('SIGINT', () => sdk.shutdown());
   process.on('SIGQUIT', () => sdk.shutdown());

--- a/Backend/backend.js
+++ b/Backend/backend.js
@@ -114,7 +114,10 @@ class ServiceResourceDetector {
 }
 
 async function opentelemetry_init() {
-  let sdk = opentelemetry_create();
+  let sdk;
+  try {
+    sdk = opentelemetry_create();
+  } catch(e){}
   process.on('exit', () => sdk.shutdown());
   process.on('SIGINT', () => sdk.shutdown());
   process.on('SIGQUIT', () => sdk.shutdown());
@@ -135,7 +138,7 @@ function opentelemetry_create() {
     metricReader: new PeriodicExportingMetricReader({
       exporter: new OTLPMetricExporter({
         url: process.env.OPENTELEMETRY_METRICS_API_ENDPOINT,
-        headers: { Authorization: process.env.OPENTELEMETRY_METRICS_API_TOKEN },
+        headers: { Authorization: process.env.OPENTELEMETRY_METRICS_API_TOKEN ? process.env.OPENTELEMETRY_METRICS_API_TOKEN : 'undefined'},
         temporalityPreference: AggregationTemporality.DELTA
       }),
       exportIntervalMillis: 5000,

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "philbot-backend",
-  "version": "3.12.3",
+  "version": "3.12.4",
   "author": "philipp-lengauer <p.lengauer@gmail.com>",
   "dependencies": {
     "form-data": "^4.0.0",

--- a/DiscordGateway2HTTP/opentelemetry.js
+++ b/DiscordGateway2HTTP/opentelemetry.js
@@ -130,7 +130,7 @@ function create() {
     metricReader: new opentelemetry_metrics.PeriodicExportingMetricReader({
       exporter: new opentelemetry_metrics_otlp.OTLPMetricExporter({
         url: process.env.OPENTELEMETRY_METRICS_API_ENDPOINT,
-        headers: { Authorization: process.env.OPENTELEMETRY_METRICS_API_TOKEN },
+        headers: { Authorization: process.env.OPENTELEMETRY_METRICS_API_TOKEN ? process.env.OPENTELEMETRY_METRICS_API_TOKEN : 'undefined'},
         temporalityPreference: opentelemetry_metrics.AggregationTemporality.DELTA
       }),
       exportIntervalMillis: 5000,

--- a/DiscordGateway2HTTP/package.json
+++ b/DiscordGateway2HTTP/package.json
@@ -1,6 +1,6 @@
 {
   "name": "philbot-discordgateway2http",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "author": "philipp-lengauer <p.lengauer@gmail.com>",
   "description": "connects to the discord gateway and forwards all events via HTTP(s) to a pre-configured endpoint",
   "type": "module",


### PR DESCRIPTION
Checking if reading from an env returns the value undefined and assigning the string the value undefined, so the otlp-metrics doesn't crash until fix in the package is applied.
Worked locally for both services (no load/requests, but was reproducible on simple docker run).

Related issue: https://github.com/open-telemetry/opentelemetry-js/issues/4541