### PR TITLE
Only run one integration test at the time

### DIFF
--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -13,6 +13,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
+
+concurrency:
+  group: test-integration
       
 jobs:
   observe:


### PR DESCRIPTION
integration tests share identity and credentials. so we should only run one at a time