### PR TITLE
Fix collector endpoint for selfmonitoring CI and other bots

### DIFF
--- a/Deployment/Config/var/lib/philbot-config/collector.yaml
+++ b/Deployment/Config/var/lib/philbot-config/collector.yaml
@@ -2,6 +2,7 @@ receivers:
   otlp:
     protocols:
       http:
+        endpoint: 0.0.0.0:4318
 
 exporters:
   otlphttp/logs:


### PR DESCRIPTION
https://opentelemetry.io/blog/2024/hardening-the-collector-one/

the collector default config chnaged from 0.0.0.0 to localhost for the endpoint. that means, without providing an explicit endpoint, the collector will bind to the localhost network device and will no longer be reachable from outside